### PR TITLE
Add minimal resolver plugin using a custom media linker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,56 @@
+name: Run tests
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "*.md"
+      - "*.in"
+      - "*.txt"
+
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "*.md"
+      - "*.in"
+      - "*.txt"
+
+jobs:
+  test-otio-0130:
+    env:
+      plugin_name: "otio_openassetio"
+
+    name: "OpenTimelineIO 0.13.0"
+    strategy:
+      matrix:
+        python-version: [3.9, ]
+        os: [ubuntu-latest, macos-latest] # windows-latest when wheel is in place
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest pytest-cov OpenTimelineIO==0.13.0
+
+      - name: Install Plugin
+        run: |
+          pip install -e .
+
+      - name: Lint with flake8
+        run: |
+          flake8 --show-source --statistics
+
+      - name: Test with pytest
+        run: |
+          pytest
+
+        shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,11 +16,11 @@ on:
       - "*.txt"
 
 jobs:
-  test-otio-0130:
+  test:
     env:
       plugin_name: "otio_openassetio"
 
-    name: "OpenTimelineIO 0.13.0"
+    name: Test
     strategy:
       matrix:
         python-version: [3.9, ]
@@ -36,10 +36,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Clone OpenAssetIO
+        uses: actions/checkout@v2
+        with:
+          repository: TheFoundryVisionmongers/OpenAssetIO
+          path: dependencies/OpenAssetIO
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov OpenTimelineIO==0.13.0
+          pip install dependencies/OpenAssetIO
 
       - name: Install Plugin
         run: |
@@ -47,10 +54,11 @@ jobs:
 
       - name: Lint with flake8
         run: |
-          flake8 --show-source --statistics
+          flake8 --show-source --statistics otio_openassetio tests
 
       - name: Test with pytest
         run: |
-          pytest
-
+          pytest tests
+        env:
+          OPENASSETIO_PLUGIN_PATH: dependencies/OpenAssetIO/resources/examples/manager/BasicAssetLibrary/plugin
         shell: bash

--- a/.github/workflows/create_draft_release.yaml
+++ b/.github/workflows/create_draft_release.yaml
@@ -1,0 +1,33 @@
+name: Create draft release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    env:
+      plugin_name: "otio_openassetio"
+
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: otio-openassetio{{ github.ref }}
+          body: |
+            Changes in this release
+            * something
+            * something
+
+            Please upgrade your adapter with `pip install --upgrade ${{ env.plugin_name }}`
+          draft: true
+          prerelease: false

--- a/.github/workflows/deploy_package.yaml
+++ b/.github/workflows/deploy_package.yaml
@@ -1,0 +1,31 @@
+name: Upload Python Package to PyPi
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        # You need to add a token to your repo's secrets
+        # Make sure you match the name of your secret to the token name below.
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        python setup.py sdist bdist_wheel --universal
+
+        # Make sure everything works on testpypi before releasing on pypi
+        twine upload --repository pypi dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.egg-info
 __pycache__
 *.pyc
+dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv
+*.egg-info
+__pycache__
+*.pyc

--- a/README.md
+++ b/README.md
@@ -10,18 +10,81 @@ the plugin's media linker is enabled.
 > Note: This project is currently in it's early alpha stages, more
 > information and features coming soon!
 
-## Testing
+## Configuration
 
-Initial setup
+The media linker currently takes the following arguments, `settings` is
+optional, and should be any required settings for the chosen manager:
+
+```
+{
+    "identifier": "<required manager identifier>"
+    "settings": { ...  }
+}
+```
+
+Eg:
+
+```python
+linker_args = {
+    "identifier": "org.openassetio.examples.manager.bal",
+    "settings": {
+        "library_path": "my_library.json"
+    }
+}
+
+timeline = otio.adapters.read_from_string(
+    otio_str,
+    media_linker_name="openassetio_media_linker",
+    media_linker_argument_map=linker_args
+)
+```
+
+## Setup and testing
+
+At this stage, due to the alpha nature of this project, and OpenAssetIO
+itself, setup is somewhat manual.
+
+First, clone this repository:
+
+```shell
+git clone https://github.com/TheFoundryVisionmongers/otio-openassetio
+cd otio-openassetio
+```
+
+We recommend a local venv, but feel feel to adapt this to your needs:
 
 ```shell
 python -m venv .venv
 . .venv/bin/activate
+```
+
+### Dependencies
+
+To use the linker in OpenTimelineIO `openassetio` needs to be installed.
+At present, this requires installation from source:
+
+```shell
+mkdir dependencies
+git clone git@github.com:TheFoundryVisionmongers/OpenAssetIO.git dependencies/OpenAssetIO
+pip install dependencies/OpenAssetIO
+```
+
+### OpenTimelineIO plugin
+
+The dev extras will also install the required testing dependencies.
+
+```shell
 pip install -e '.[dev]'
 ```
 
-```python
-pytest
+### Testing
+
+To run the tests we need the `BasicAssetLibrary` example manager plugin from
+the OpenAssetIO repository.
+
+```shell
+export OPENASSETIO_PLUGIN_PATH=dependencies/OpenAssetIO/resources/examples/manager/BasicAssetLibrary/plugin
+pytest tests
 ```
 
 ## Licensing

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# OpenAssetIO support for OpenTimelineIO
+
+This project adds basic asset resolution capabilities to OpenTimelineIO
+via the OpenAssetIO API.
+
+This allows `.otio` media references to point to OpenAssetIO entity
+references instead of file URLs. These will be transparently resolved if
+the plugin's media linker is enabled.
+
+> Note: This project is currently in it's early alpha stages, more
+> information and features coming soon!
+
+## Testing
+
+Initial setup
+
+```shell
+python -m venv .venv
+. .venv/bin/activate
+pip install -e '.[dev]'
+```
+
+```python
+pytest
+```
+
+## Licensing
+
+This project is licensed under the
+[Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt).

--- a/otio_openassetio/__init__.py
+++ b/otio_openassetio/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Foundry Visionmongers Ltd
+# SPDX-License-Identifier: Apache-2.0

--- a/otio_openassetio/operations/__init__.py
+++ b/otio_openassetio/operations/__init__.py
@@ -1,4 +1,2 @@
 # Copyright The Foundry Visionmongers Ltd
-#
 # SPDX-License-Identifier: Apache-2.0
-#

--- a/otio_openassetio/operations/__init__.py
+++ b/otio_openassetio/operations/__init__.py
@@ -1,0 +1,4 @@
+# Copyright The Foundry Visionmongers Ltd
+#
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/otio_openassetio/operations/openassetio_media_linker.py
+++ b/otio_openassetio/operations/openassetio_media_linker.py
@@ -3,21 +3,173 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """
-A media linker that resolves media reference URLs via OpenAssetIO if they
-contain a valid entity reference.
+A media linker that resolves media reference URLs via OpenAssetIO if
+their target_url is set to a valid entity reference.
 """
 
+from collections import namedtuple
 
-import re
+from openassetio import log
+from openassetio.hostAPI import HostInterface, Session
+from openassetio.specifications import LocaleSpecification
+from openassetio.pluginSystem import PluginSystemManagerFactory
+
 import opentimelineio as otio
+
+
+#
+# Media Linker
+#
 
 
 def link_media_reference(in_clip, media_linker_argument_map):
 
+    # Once https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/247
+    # is implemented, we can more concisely handle ImageSequenceReference,
+    # but we will need to convert file:///a/path/sequence.%04d.ext to the
+    # component fields required by OTIO. For now, we only handle simple
+    # ExternalReference schemas.
+    # We can then also set all other relevant properties of the
+    # Clip/MediaReference based on trait properties.
+    # For now, keep it simple and just resolve the URL
+
     mr = in_clip.media_reference
 
-    if not mr:
+    if not isinstance(mr, otio.schema.ExternalReference):
         return
 
-    if isinstance(mr, otio.schema.ExternalReference):
-        mr.target_url = "<resolved>"
+    session_state = _sessionState(media_linker_argument_map)
+    manager = session_state.session.currentManager()
+
+    if not extract_one(manager.isEntityReference([mr.target_url])):
+        return
+
+    context = session_state.context
+    context.locale.clipName = in_clip.name
+
+    mr.target_url = extract_one(
+        manager.resolveEntityReference([mr.target_url], context)
+    )
+
+
+#
+# OpenAssetIO classes
+#
+
+# Due to the way OTIO imports plugins, we can't factor these out into
+# their own module. It thinks this code is part of the the
+# opentimelineio.adapters module:
+#
+#   from .shared import OTIOHostInterface
+#   > ModuleNotFoundError: No module named 'opentimelineio.adapters.shared'
+#
+# Its not really a problem right now as this is the only place we need
+# them.
+
+
+class OTIOHostInterface(HostInterface):
+    """
+    An OpenAssetIO HostInterface implementation for the OTIO media linker
+    """
+
+    def identifier(self):
+        return "com.foundry.otio-openassetio.medialinker"
+
+    def displayName(self):
+        return "OpenTimelineIO OpenAssetIO Media Linker plugin"
+
+
+class OTIOClipLocale(LocaleSpecification):
+    """
+    An OpenAssetIO Locale that represents API calls for a track clip
+    """
+
+    _type = "timeline.track.clip.otio"
+
+    clipName = LocaleSpecification.TypedProperty(
+        str,
+        doc="The name of the clip in the timeline for which the reference is being resolved.",
+    )
+
+
+#
+# Helpers
+#
+
+# Until we have singular conveniences in hostAPI.Manager (see
+# https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/107),
+# then we need to unpack the batch result and raise any exceptions
+# returned for our singular reference.
+
+
+def extract_one(results):
+    """
+    A convenience to extract the first result from a batch OpenAssetIO
+    result, raising if it is an exception.
+    """
+    result = results[0]
+    if isinstance(result, Exception):
+        raise result
+    return result
+
+
+#
+# Session Management
+#
+
+# Ideally we would tie a session into the lifetime of a media linker, but
+# as they're free functions, rather than instanitated classes, we don't
+# know when they are needed. This simple/naive approach effectively
+# persists a session/context for as long as the args to the linker are
+# the same. This is not ideal. The context lifetime should really be
+# tied to each specific Timeline. That is an exercise for another day.
+
+SessionState = namedtuple("SessionState", ("session", "context"))
+
+_last_args = None
+_session_state = None
+
+
+def _sessionState(args: dict) -> Session:
+    """
+    Returns a SessionState configured for the supplied settings. If the
+    settings are the same as the last invocation, the previously
+    constructed state will be reused.
+    """
+
+    global _last_args
+    global _session_state
+
+    if args != _last_args:
+        _session_state = None
+
+    if _session_state is None:
+        _last_args = args
+        _session_state = _createSessionState(args)
+
+    return _session_state
+
+
+def _createSessionState(args: dict) -> SessionState:
+    """
+    Configures a new SessionState with the manager + settings from the
+    supplied args. A new Context is created and configured for read NB
+    with the correct locale.
+    """
+
+    host = OTIOHostInterface()
+    logger = log.SeverityFilter(log.ConsoleLogger())
+    factory = PluginSystemManagerFactory(logger)
+
+    session = Session(host, logger, factory)
+    session.useManager(args["identifier"], args.get("settings", {}))
+
+    # The lifetime of the context would ideally be tied to each specific
+    # call to read_from_string or similar. Maybe we could introspect
+    # each clip and see which Timeline it belongs to. This will do for
+    # now though and is better than making a context per clip.
+    context = session.createContext()
+    context.access = context.kRead
+    context.locale = OTIOClipLocale()
+
+    return SessionState(session=session, context=context)

--- a/otio_openassetio/operations/openassetio_media_linker.py
+++ b/otio_openassetio/operations/openassetio_media_linker.py
@@ -1,7 +1,5 @@
 # Copyright The Foundry Visionmongers Ltd
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 """
 A media linker that resolves media reference URLs via OpenAssetIO if
 their target_url is set to a valid entity reference.

--- a/otio_openassetio/operations/openassetio_media_linker.py
+++ b/otio_openassetio/operations/openassetio_media_linker.py
@@ -1,0 +1,23 @@
+# Copyright The Foundry Visionmongers Ltd
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""
+A media linker that resolves media reference URLs via OpenAssetIO if they
+contain a valid entity reference.
+"""
+
+
+import re
+import opentimelineio as otio
+
+
+def link_media_reference(in_clip, media_linker_argument_map):
+
+    mr = in_clip.media_reference
+
+    if not mr:
+        return
+
+    if isinstance(mr, otio.schema.ExternalReference):
+        mr.target_url = "<resolved>"

--- a/otio_openassetio/plugin_manifest.json
+++ b/otio_openassetio/plugin_manifest.json
@@ -1,0 +1,11 @@
+{
+  "OTIO_SCHEMA": "PluginManifest.1",
+  "media_linkers": [
+    {
+      "OTIO_SCHEMA": "MediaLinker.1",
+      "name": "openassetio_media_linker",
+      "execution_scope": "in process",
+      "filepath": "operations/openassetio_media_linker.py"
+    }
+  ]
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@
 #
 [tool:pytest]
 addopts = -W ignore::DeprecationWarning
+
+[flake8]
+max-line-length: 99

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+# Copyright The Foundry Visionmongers Ltd
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+[tool:pytest]
+addopts = -W ignore::DeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,5 @@
 # Copyright The Foundry Visionmongers Ltd
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 [tool:pytest]
 addopts = -W ignore::DeprecationWarning
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 # Copyright Contributors to the OpenTimelineIO project
 # Copyright The Foundry Visionmongers Ltd
-#
 # SPDX-License-Identifier: Apache-2.0
-#
 
 import io
 import setuptools

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,46 @@
+# Copyright Contributors to the OpenTimelineIO project
+# Copyright The Foundry Visionmongers Ltd
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import io
+import setuptools
+
+with io.open("README.md", "r", encoding="utf-8") as f:
+    long_description = f.read()
+
+
+setuptools.setup(
+    name="otio-openassetio",
+    author="The Foundry Visionmongers Ltd",
+    author_email="tom@foundry.com",
+    version="0.0.0",
+    description="Adds asset resolution to OpenTimelineIO via the OpenAssetIO API",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    # Replace url with your repo
+    url="https://github.com/TheFoundryVisionmnogers/otio-openassetio",
+    packages=setuptools.find_packages(),
+    entry_points={"opentimelineio.plugins": "otio_openassetio = otio_openassetio"},
+    package_data={
+        "otio_openassetio": [
+            "plugin_manifest.json",
+        ],
+    },
+    install_requires=["OpenTimelineIO >= 0.12.0"],
+    extras_require={"dev": ["black", "pytest", "twine"]},
+    classifiers=[
+        "Development Status :: 2 - Pre-Alpha",
+        "Intended Audience :: Developers",
+        "Topic :: Multimedia :: Video",
+        "Topic :: Multimedia :: Video :: Display",
+        "Topic :: Multimedia :: Video :: Non-Linear Editor",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Operating System :: POSIX :: Linux ",
+        "License :: OSI Approved :: Apache Software License",
+        "Natural Language :: English",
+    ],
+)

--- a/tests/resources/test_entity_library.json
+++ b/tests/resources/test_entity_library.json
@@ -1,0 +1,10 @@
+{
+  "entities": {
+    "asset1": {
+      "versions": [{ "primary_string": "file:///asset/1" }]
+    },
+    "asset2": {
+      "versions": [{ "primary_string": "file:///asset/2" }]
+    }
+  }
+}

--- a/tests/test_otio_openassetio.py
+++ b/tests/test_otio_openassetio.py
@@ -1,0 +1,52 @@
+# Copyright The Foundry Visionmongers Ltd
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+import opentimelineio as otio
+
+
+def test_when_media_linker_enabled_then_references_are_resolved():
+    raw = """{
+        "OTIO_SCHEMA": "Timeline.1",
+        "name": "Linker Test",
+        "tracks": {
+            "OTIO_SCHEMA": "Stack.1",
+            "children": [
+                {
+                    "OTIO_SCHEMA": "Track.1",
+                    "kind": "Video",
+                    "children": [
+                        {
+                            "OTIO_SCHEMA": "Clip.1",
+                            "media_reference": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "target_url": "bal:///assetClipA"
+                            },
+                            "name": "A",
+                            "source_range": {
+                                "OTIO_SCHEMA": "TimeRange.1",
+                                "duration": {
+                                    "OTIO_SCHEMA": "RationalTime.1",
+                                    "rate": 24,
+                                    "value": 50
+                                },
+                                "start_time": {
+                                    "OTIO_SCHEMA": "RationalTime.1",
+                                    "rate": 24,
+                                    "value": 0.0
+                                }
+                            }
+
+                        }
+                    ]
+                }
+            ]
+        }
+    }"""
+
+    timeline = otio.adapters.read_from_string(
+        raw, media_linker_name="openassetio_media_linker"
+    )
+
+    for clip in timeline.tracks[0]:
+        assert clip.media_reference.target_url == "<resolved>"

--- a/tests/test_otio_openassetio.py
+++ b/tests/test_otio_openassetio.py
@@ -2,10 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+
+import os
+
+import pytest
+
 import opentimelineio as otio
 
 
-def test_when_media_linker_enabled_then_references_are_resolved():
+def test_when_linker_used_then_references_are_resolved(bal_linker_args):
     raw = """{
         "OTIO_SCHEMA": "Timeline.1",
         "name": "Linker Test",
@@ -20,9 +25,9 @@ def test_when_media_linker_enabled_then_references_are_resolved():
                             "OTIO_SCHEMA": "Clip.1",
                             "media_reference": {
                                 "OTIO_SCHEMA": "ExternalReference.1",
-                                "target_url": "bal:///assetClipA"
+                                "target_url": "bal:///asset1"
                             },
-                            "name": "A",
+                            "name": "Asset1",
                             "source_range": {
                                 "OTIO_SCHEMA": "TimeRange.1",
                                 "duration": {
@@ -36,7 +41,48 @@ def test_when_media_linker_enabled_then_references_are_resolved():
                                     "value": 0.0
                                 }
                             }
-
+                        },
+                        {
+                            "OTIO_SCHEMA": "Clip.1",
+                            "media_reference": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "target_url": "bal:///asset2"
+                            },
+                            "name": "Asset2",
+                            "source_range": {
+                                "OTIO_SCHEMA": "TimeRange.1",
+                                "duration": {
+                                    "OTIO_SCHEMA": "RationalTime.1",
+                                    "rate": 24,
+                                    "value": 50
+                                },
+                                "start_time": {
+                                    "OTIO_SCHEMA": "RationalTime.1",
+                                    "rate": 24,
+                                    "value": 0.0
+                                }
+                            }
+                        },
+                        {
+                            "OTIO_SCHEMA": "Clip.1",
+                            "media_reference": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "target_url": "file:///not/an/asset"
+                            },
+                            "name": "NotAnAsset",
+                            "source_range": {
+                                "OTIO_SCHEMA": "TimeRange.1",
+                                "duration": {
+                                    "OTIO_SCHEMA": "RationalTime.1",
+                                    "rate": 24,
+                                    "value": 50
+                                },
+                                "start_time": {
+                                    "OTIO_SCHEMA": "RationalTime.1",
+                                    "rate": 24,
+                                    "value": 0.0
+                                }
+                            }
                         }
                     ]
                 }
@@ -45,8 +91,56 @@ def test_when_media_linker_enabled_then_references_are_resolved():
     }"""
 
     timeline = otio.adapters.read_from_string(
-        raw, media_linker_name="openassetio_media_linker"
+        raw,
+        media_linker_name="openassetio_media_linker",
+        media_linker_argument_map=bal_linker_args,
     )
 
-    for clip in timeline.tracks[0]:
-        assert clip.media_reference.target_url == "<resolved>"
+    expected = ("file:///asset/1", "file:///asset/2", "file:///not/an/asset")
+
+    for clip, expected in zip(timeline.tracks[0], expected):
+        assert clip.media_reference.target_url == expected
+
+
+@pytest.fixture()
+def bal_linker_args():
+    """
+    Provides an arguments dict for the media linker plugin that
+    configures it to use the BAL manager, and test resources library.
+    """
+    return {
+        "identifier": "org.openassetio.examples.manager.bal",
+        "settings": {
+            "library_path": os.path.join(
+                os.path.dirname(__file__), "resources", "test_entity_library.json"
+            )
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def bal_plugin_env(base_dir, monkeypatch):
+    """
+    Provides a modified environment with the BasicAssetLibrary
+    plugin on the OpenAssetIO search path based on the expected
+    dependencies install location
+    """
+    plugin_dir = os.path.join(
+        base_dir,
+        "dependencies",
+        "OpenAssetIO",
+        "resources",
+        "examples",
+        "manager",
+        "BasicAssetLibrary",
+        "plugin",
+    )
+    monkeypatch.setenv("OPENASSETIO_PLUGIN_PATH", plugin_dir)
+
+
+@pytest.fixture()
+def base_dir():
+    """
+    Provides the path to the base directory of this codebase.
+    """
+    return os.path.dirname(os.path.dirname(__file__))

--- a/tests/test_otio_openassetio.py
+++ b/tests/test_otio_openassetio.py
@@ -1,8 +1,5 @@
 # Copyright The Foundry Visionmongers Ltd
-#
 # SPDX-License-Identifier: Apache-2.0
-#
-
 import os
 
 import pytest


### PR DESCRIPTION
Hopefully gets us pretty much there with with https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/215. Keeping to the https://github.com/OpenTimelineIO/otio-plugin-template as much as it can.

It is very minimal right now in terms of functionality, pending the changes were making to move to [trait-based resolution](https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/247). Hopefully it illustrates a representative use case, and will enable some real-world exploration of assetized EDLs.

There are all sorts of fun things we can do later, especially around the other media reference properties, and the use of inherited metadata to drive aspects of the resolution process.

A working example of CI is available [here](https://github.com/foundrytom/otio-openassetio/pull/1).

I'll fix the too-long commit titles when squashing.