### PR TITLE
Migrate to the new OpenAssetIO unified entity data model

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,4 @@ jobs:
         run: |
           . dist/bin/activate
           pytest tests
-        env:
-          OPENASSETIO_PLUGIN_PATH: dependencies/OpenAssetIO/resources/examples/manager/BasicAssetLibrary/plugin
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,9 +24,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9, ]
-        os: [ubuntu-latest, macos-latest] # windows-latest when wheel is in place
 
-    runs-on: ${{ matrix.os }}
+    runs-on: "ubuntu-latest"
 
     steps:
       - uses: actions/checkout@v2
@@ -40,24 +39,48 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: TheFoundryVisionmongers/OpenAssetIO
+          ref: feature/181-coreCppBuild
           path: dependencies/OpenAssetIO
+
+      # Don't cache this as python does some system package installs
+      # that won't be cached and it then breaks on the next run.
+      - name: Build OpenAssetIO
+        run: |
+          pip install conan==1.45.0 cmake==3.21 ninja==1.10.2.3 cpplint==1.5.5
+          conan profile new default --detect --force
+          conan profile update settings.compiler.libcxx=libstdc++ default
+          conan install --install-folder ~/.conan --build=missing dependencies/OpenAssetIO/resources/build
+          cmake -S dependencies/OpenAssetIO -B build  \
+            --toolchain ~/.conan/conan_paths.cmake \
+            --install-prefix $GITHUB_WORKSPACE/dist
+          cmake --build build --target openassetio-python-py-install
+
+      - name: Clone OpenAssetIO-MediaCreation
+        uses: actions/checkout@v2
+        with:
+          repository: TheFoundryVisionmongers/OpenAssetIO-MediaCreation
+          path: dependencies/OpenAssetIO-MediaCreation
 
       - name: Install dependencies
         run: |
+          . dist/bin/activate
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov OpenTimelineIO==0.13.0
-          pip install dependencies/OpenAssetIO
+          pip install dependencies/OpenAssetIO-MediaCreation
 
       - name: Install Plugin
         run: |
+          . dist/bin/activate
           pip install -e .
 
       - name: Lint with flake8
         run: |
+          . dist/bin/activate
           flake8 --show-source --statistics otio_openassetio tests
 
       - name: Test with pytest
         run: |
+          . dist/bin/activate
           pytest tests
         env:
           OPENASSETIO_PLUGIN_PATH: dependencies/OpenAssetIO/resources/examples/manager/BasicAssetLibrary/plugin

--- a/README.md
+++ b/README.md
@@ -60,14 +60,28 @@ python -m venv .venv
 
 ### Dependencies
 
-To use the linker in OpenTimelineIO `openassetio` needs to be installed.
-At present, this requires installation from source:
+To use the linker in OpenTimelineIO `openassetio` and
+`openassetio_mediacreation` need to be installed.
+
+At present, for OpenAssetIO, we require installation from source of the
+`feature/181-coreCppBuild` branch.
 
 ```shell
 mkdir dependencies
-git clone git@github.com:TheFoundryVisionmongers/OpenAssetIO.git dependencies/OpenAssetIO
-pip install dependencies/OpenAssetIO
+git clone -b feature/181-coreCppBuild git@github.com:TheFoundryVisionmongers/OpenAssetIO.git dependencies/OpenAssetIO
+cmake -S dependencies/OpenAssetIO -B build
+cmake --build build --target openassetio-python-py-install
+. dist/bin activate
 ```
+
+The Media Creation library is more straightforward.
+
+```shell
+git clone git@github.com:TheFoundryVisionmongers/OpenAssetIO-MediaCreation
+pip install dependencies/OpenAssetIO-MediaCreation
+```
+
+You will now be in a Python virtual environment with `openassetio` and `openassetio_mediacreation` available.
 
 ### OpenTimelineIO plugin
 

--- a/README.md
+++ b/README.md
@@ -93,11 +93,14 @@ pip install -e '.[dev]'
 
 ### Testing
 
-To run the tests we need the `BasicAssetLibrary` example manager plugin from
-the OpenAssetIO repository.
+The tests make us of the `BasicAssetLibrary` example manager plugin from
+the OpenAssetIO repository. They include a `pytest` fixture that extends
+the process environment to set the OpenAssetIO plugin search paths to
+the dependencies directory as installed above.
+
+Running the tests is then as follows:
 
 ```shell
-export OPENASSETIO_PLUGIN_PATH=dependencies/OpenAssetIO/resources/examples/manager/BasicAssetLibrary/plugin
 pytest tests
 ```
 

--- a/tests/resources/test_entity_library.json
+++ b/tests/resources/test_entity_library.json
@@ -1,10 +1,10 @@
 {
   "entities": {
     "asset1": {
-      "versions": [{ "primary_string": "file:///asset/1" }]
+      "versions": [{ "traits": {"locatableContent": { "location": "file:///asset/1" }}}]
     },
     "asset2": {
-      "versions": [{ "primary_string": "file:///asset/2" }]
+      "versions": [{ "traits": {"locatableContent": { "location": "file:///asset/2" }}}]
     }
   }
 }


### PR DESCRIPTION
Draft till https://github.com/TheFoundryVisionmongers/OpenAssetIO-MediaCreation/pull/2, https://github.com/TheFoundryVisionmongers/OpenAssetIO-MediaCreation/pull/3 and https://github.com/TheFoundryVisionmongers/OpenAssetIO/pull/363 are merged.

Once in, this switches to using the new trait-centric model for resolution.