### PR TITLE
Pin dependencies to release tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,8 +38,8 @@ jobs:
       - name: Clone OpenAssetIO
         uses: actions/checkout@v2
         with:
-          repository: TheFoundryVisionmongers/OpenAssetIO
-          ref: feature/181-coreCppBuild
+          repository: OpenAssetIO/OpenAssetIO
+          ref: v1.0.0-alpha.1
           path: dependencies/OpenAssetIO
 
       # Don't cache this as python does some system package installs
@@ -58,7 +58,8 @@ jobs:
       - name: Clone OpenAssetIO-MediaCreation
         uses: actions/checkout@v2
         with:
-          repository: TheFoundryVisionmongers/OpenAssetIO-MediaCreation
+          repository: OpenAssetIO/OpenAssetIO-MediaCreation
+          ref: v1.0.0-alpha.1
           path: dependencies/OpenAssetIO-MediaCreation
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ To use the linker in OpenTimelineIO `openassetio` and
 `openassetio_mediacreation` need to be installed.
 
 At present, for OpenAssetIO, we require installation from source of the
-`feature/181-coreCppBuild` branch.
+`v0.0.0-alpha.1` tag.
 
 ```shell
 mkdir dependencies
-git clone -b feature/181-coreCppBuild git@github.com:TheFoundryVisionmongers/OpenAssetIO.git dependencies/OpenAssetIO
+git clone -b v1.0.0-alpha.1 git@github.com:OpenAssetIO/OpenAssetIO.git dependencies/OpenAssetIO
 cmake -S dependencies/OpenAssetIO -B build
 cmake --build build --target openassetio-python-py-install
 . dist/bin activate
@@ -77,7 +77,7 @@ cmake --build build --target openassetio-python-py-install
 The Media Creation library is more straightforward.
 
 ```shell
-git clone git@github.com:TheFoundryVisionmongers/OpenAssetIO-MediaCreation
+git clone -b v1.0.0-alpha.1 git@github.com:OpenAssetIO/OpenAssetIO-MediaCreation
 pip install dependencies/OpenAssetIO-MediaCreation
 ```
 


### PR DESCRIPTION
Closes #7.

Now we have tags for `OpenAssetIO` and `OpenAssetIO-MediaCreation` we should be stable.