### PR TITLE
Update OTIO to newer OpenAssetIO api

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        python-version: [3.9, ]
+        python-version: [3.9]
 
     runs-on: "ubuntu-latest"
 
@@ -35,55 +35,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Clone OpenAssetIO
-        uses: actions/checkout@v2
-        with:
-          repository: OpenAssetIO/OpenAssetIO
-          ref: v1.0.0-alpha.1
-          path: dependencies/OpenAssetIO
-
-      # Don't cache this as python does some system package installs
-      # that won't be cached and it then breaks on the next run.
-      - name: Build OpenAssetIO
-        run: |
-          pip install conan cmake==3.21 ninja==1.10.2.3 cpplint==1.5.5
-          conan profile new default --detect --force
-          conan profile update settings.compiler.libcxx=libstdc++ default
-          conan install --install-folder ~/.conan --build=missing \
-            -c tools.system.package_manager:mode=install \
-            -c tools.system.package_manager:sudo=True \
-             dependencies/OpenAssetIO/resources/build
-          cmake -S dependencies/OpenAssetIO -B build  \
-            --toolchain ~/.conan/conan_paths.cmake \
-            --install-prefix $GITHUB_WORKSPACE/dist
-          cmake --build build --target openassetio-python-py-install
-
-      - name: Clone OpenAssetIO-MediaCreation
-        uses: actions/checkout@v2
-        with:
-          repository: OpenAssetIO/OpenAssetIO-MediaCreation
-          ref: v1.0.0-alpha.1
-          path: dependencies/OpenAssetIO-MediaCreation
-
-      - name: Install dependencies
-        run: |
-          . dist/bin/activate
-          python -m pip install --upgrade pip
-          pip install flake8 pytest pytest-cov OpenTimelineIO==0.13.0
-          pip install dependencies/OpenAssetIO-MediaCreation
-
       - name: Install Plugin
-        run: |
-          . dist/bin/activate
-          pip install -e .
+        run: pip install -e .[dev]
 
       - name: Lint with flake8
-        run: |
-          . dist/bin/activate
-          flake8 --show-source --statistics otio_openassetio tests
+        run: flake8 --show-source --statistics otio_openassetio tests
 
       - name: Test with pytest
-        run: |
-          . dist/bin/activate
-          pytest tests
+        run: pytest tests
         shell: bash

--- a/README.md
+++ b/README.md
@@ -58,30 +58,18 @@ python -m venv .venv
 . .venv/bin/activate
 ```
 
-### Dependencies
+This project is dependent on :
 
-To use the linker in OpenTimelineIO `openassetio` and
-`openassetio_mediacreation` need to be installed.
+- `opentimelineio`
+- `openassetio`
+- `openassetio_mediacreation`
 
-At present, for OpenAssetIO, we require installation from source of the
-`v0.0.0-alpha.1` tag.
-
-```shell
-mkdir dependencies
-git clone -b v1.0.0-alpha.1 git@github.com:OpenAssetIO/OpenAssetIO.git dependencies/OpenAssetIO
-cmake -S dependencies/OpenAssetIO -B build
-cmake --build build --target openassetio-python-py-install
-. dist/bin activate
-```
-
-The Media Creation library is more straightforward.
+These dependencies, and the plugin itself, can be installed from the
+project root via
 
 ```shell
-git clone -b v1.0.0-alpha.1 git@github.com:OpenAssetIO/OpenAssetIO-MediaCreation
-pip install dependencies/OpenAssetIO-MediaCreation
+pip install -e .
 ```
-
-You will now be in a Python virtual environment with `openassetio` and `openassetio_mediacreation` available.
 
 ### OpenTimelineIO plugin
 
@@ -94,11 +82,12 @@ pip install -e '.[dev]'
 ### Testing
 
 The tests make us of the `BasicAssetLibrary` example manager plugin from
-the OpenAssetIO repository. They include a `pytest` fixture that extends
-the process environment to set the OpenAssetIO plugin search paths to
-the dependencies directory as installed above.
+the OpenAssetIO repository. If `BasicAssetLibrary` is installed into
+your environment, (which it will be if you've installed the dev extras),
+it will be discovered automatically via [importlib](https://docs.python.org/3/library/importlib.html) package discovery.
 
-Running the tests is then as follows:
+Therefore, the tests can be run from the root of the project directory,
+as follows:
 
 ```shell
 pytest tests

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,20 @@ setuptools.setup(
             "plugin_manifest.json",
         ],
     },
-    install_requires=["OpenTimelineIO >= 0.12.0"],
-    extras_require={"dev": ["black", "pytest", "twine"]},
+    install_requires=[
+        "OpenTimelineIO >= 0.12.0",
+        "openassetio == 1.0.0a7",
+        "openassetio-mediacreation == 1.0.0a2",
+    ],
+    extras_require={
+        "dev": [
+            "black",
+            "pytest",
+            "flake8",
+            "twine",
+            "openassetio-manager-bal == 1.0.0a3"
+        ]
+    },
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",

--- a/tests/resources/test_entity_library_missing_asset.json
+++ b/tests/resources/test_entity_library_missing_asset.json
@@ -10,17 +10,6 @@
           }
         }
       ]
-    },
-    "asset2": {
-      "versions": [
-        {
-          "traits": {
-            "openassetio-mediacreation:content.LocatableContent": {
-              "location": "file:///asset/2"
-            }
-          }
-        }
-      ]
     }
   }
 }

--- a/tests/resources/test_entity_library_no_locatable_content.json
+++ b/tests/resources/test_entity_library_no_locatable_content.json
@@ -1,0 +1,18 @@
+{
+  "entities": {
+    "asset1": {
+      "versions": [
+        {
+          "traits": {}
+        }
+      ]
+    },
+    "asset2": {
+      "versions": [
+        {
+          "traits": {}
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_otio_openassetio.py
+++ b/tests/test_otio_openassetio.py
@@ -5,10 +5,9 @@ import os
 import pytest
 
 import opentimelineio as otio
+from openassetio import exceptions
 
-
-def test_when_linker_used_then_references_are_resolved(bal_linker_args):
-    raw = """{
+raw = """{
         "OTIO_SCHEMA": "Timeline.1",
         "name": "Linker Test",
         "tracks": {
@@ -87,6 +86,8 @@ def test_when_linker_used_then_references_are_resolved(bal_linker_args):
         }
     }"""
 
+
+def test_when_linker_used_then_references_are_resolved(bal_linker_args):
     timeline = otio.adapters.read_from_string(
         raw,
         media_linker_name="openassetio_media_linker",
@@ -97,6 +98,39 @@ def test_when_linker_used_then_references_are_resolved(bal_linker_args):
 
     for clip, expected in zip(timeline.tracks[0], expected):
         assert clip.media_reference.target_url == expected
+
+
+def test_when_linker_used_with_incorrect_data_exception_thrown(
+    bal_linker_args_missing_asset,
+):
+    with pytest.raises(exceptions.EntityResolutionError):
+        otio.adapters.read_from_string(
+            raw,
+            media_linker_name="openassetio_media_linker",
+            media_linker_argument_map=bal_linker_args_missing_asset,
+        )
+
+
+def test_when_manager_cant_be_found_exception_thrown(
+    bal_linker_args_malformed_manager
+):
+    with pytest.raises(exceptions.PluginError):
+        otio.adapters.read_from_string(
+            raw,
+            media_linker_name="openassetio_media_linker",
+            media_linker_argument_map=bal_linker_args_malformed_manager,
+        )
+
+
+def test_when_no_locatable_content_trait_exception_thrown(
+    bal_linker_args_no_locatable_content
+):
+    with pytest.raises(exceptions.EntityResolutionError):
+        otio.adapters.read_from_string(
+            raw,
+            media_linker_name="openassetio_media_linker",
+            media_linker_argument_map=bal_linker_args_no_locatable_content,
+        )
 
 
 @pytest.fixture()
@@ -115,29 +149,55 @@ def bal_linker_args():
     }
 
 
-@pytest.fixture(autouse=True)
-def bal_plugin_env(base_dir, monkeypatch):
+@pytest.fixture()
+def bal_linker_args_malformed_manager():
     """
-    Provides a modified environment with the BasicAssetLibrary
-    plugin on the OpenAssetIO search path based on the expected
-    dependencies install location
+    Provides an arguments dict for the media linker plugin that
+    configures it to use the BAL manager, and test resources library.
     """
-    plugin_dir = os.path.join(
-        base_dir,
-        "dependencies",
-        "OpenAssetIO",
-        "resources",
-        "examples",
-        "manager",
-        "BasicAssetLibrary",
-        "plugin",
-    )
-    monkeypatch.setenv("OPENASSETIO_PLUGIN_PATH", plugin_dir)
+    return {
+        "identifier": "org.notreal.nomanager",
+        "settings": {
+            "library_path": os.path.join(
+                os.path.dirname(__file__), "resources", "test_entity_library.json"
+            )
+        },
+    }
 
 
 @pytest.fixture()
-def base_dir():
+def bal_linker_args_missing_asset():
     """
-    Provides the path to the base directory of this codebase.
+    Provides an arguments dict for the media linker plugin that
+    configures it to use the BAL manager, with data that is missing an
+    expected asset, causing an exception.
     """
-    return os.path.dirname(os.path.dirname(__file__))
+    return {
+        "identifier": "org.openassetio.examples.manager.bal",
+        "settings": {
+            "library_path": os.path.join(
+                os.path.dirname(__file__),
+                "resources",
+                "test_entity_library_missing_asset.json",
+            )
+        },
+    }
+
+
+@pytest.fixture()
+def bal_linker_args_no_locatable_content():
+    """
+    Provides an arguments dict for the media linker plugin that
+    configures it to use the BAL manager, with data that does not
+    contain the locatable content trait, causing an exception.
+    """
+    return {
+        "identifier": "org.openassetio.examples.manager.bal",
+        "settings": {
+            "library_path": os.path.join(
+                os.path.dirname(__file__),
+                "resources",
+                "test_entity_library_no_locatable_content.json",
+            )
+        },
+    }


### PR DESCRIPTION
Closes #6 

Updates the OTIO code to consume modern OpenAssetIO (>= alpha 7)
Also uses the published versions of mediacreation and BAL, rather than retrieving them.

In updating to the callback interfaces, new behaviour has been added where a resolve error is interpreted and an error rethrown, test + test data added to assert this error is thrown.

Readme updated, CI simplified to use PyPI distributions