### PR TITLE
[Core] Update to OpenAssetIO 1.0.0-beta.1.0

### DIFF
--- a/otio_openassetio/operations/openassetio_media_linker.py
+++ b/otio_openassetio/operations/openassetio_media_linker.py
@@ -7,7 +7,7 @@ their target_url is set to a valid entity reference.
 
 from collections import namedtuple
 
-from openassetio import log, exceptions
+from openassetio import log, errors
 from openassetio.access import ResolveAccess
 from openassetio.hostApi import HostInterface, ManagerFactory
 from openassetio.pluginSystem import PythonPluginSystemManagerImplementationFactory
@@ -60,9 +60,12 @@ def link_media_reference(in_clip, media_linker_argument_map):
             ResolveAccess.kRead,
             session_state.context,
         )
-        mr.target_url = LocatableContentTrait(entity_data).getLocation()
+        target_url = LocatableContentTrait(entity_data).getLocation()
+        if target_url is None:
+            raise ValueError(f"Entity '{entity_reference}' has no location")
+        mr.target_url = target_url
     except Exception as exc:
-        raise exceptions.EntityResolutionError(
+        raise errors.OpenAssetIOException(
             "Failed to resolve location from LocatableContent trait", entity_reference
         ) from exc
 

--- a/otio_openassetio/operations/openassetio_media_linker.py
+++ b/otio_openassetio/operations/openassetio_media_linker.py
@@ -155,7 +155,14 @@ def _createSessionState(args: dict) -> SessionState:
     else:
         manager = ManagerFactory.defaultManagerForInterface(host, factory, logger)
         if not manager:
-            raise RuntimeError("No default OpenAssetIO manager configured")
+            raise errors.ConfigurationException(
+                "No default OpenAssetIO manager configured"
+            )
+
+    if not manager.hasCapability(manager.Capability.kResolution):
+        raise errors.ConfigurationException(
+            f"{manager.displayName()} is not capable of resolving entity references"
+        )
 
     # The lifetime of the context would ideally be tied to each specific
     # call to read_from_string or similar. Maybe we could introspect

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     },
     install_requires=[
         "OpenTimelineIO >= 0.12.0",
-        "openassetio == 1.0.0a14",
+        "openassetio >= 1.0.0b1.rev0, < 1.0.0b2.rev0",
         "openassetio-mediacreation == 1.0.0a7",
     ],
     extras_require={
@@ -37,7 +37,7 @@ setuptools.setup(
             "pytest",
             "flake8",
             "twine",
-            "openassetio-manager-bal == 1.0.0a10"
+            "openassetio-manager-bal == 1.0.0a12"
         ]
     },
     classifiers=[

--- a/tests/test_otio_openassetio.py
+++ b/tests/test_otio_openassetio.py
@@ -134,6 +134,7 @@ def test_when_no_locatable_content_trait_exception_thrown(
     assert isinstance(err.value.__cause__, ValueError)
     assert str(err.value.__cause__) == "Entity 'bal:///asset1' has no location"
 
+
 def test_when_no_manager_setting_then_default_config_used(
     linker_args_no_settings, monkeypatch
 ):
@@ -164,9 +165,7 @@ def test_when_no_manager_setting_and_no_default_config_then_error_raised(
     linker_args_no_settings, monkeypatch
 ):
     monkeypatch.delenv(ManagerFactory.kDefaultManagerConfigEnvVarName, raising=False)
-    with pytest.raises(
-        RuntimeError, match="No default OpenAssetIO manager configured"
-    ):
+    with pytest.raises(RuntimeError, match="No default OpenAssetIO manager configured"):
         otio.adapters.read_from_string(
             raw,
             media_linker_name="openassetio_media_linker",


### PR DESCRIPTION
Update dependency versions, hence

* Avoid use of deprecated exceptions.
* Explicitly detect when an entity has no "locatableContent" trait. Previously an exception would be raised from OpenAssetIO, but this was changed to return `None` instead.
