### PR TITLE
[Build] Bump OpenAssetIO dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ setuptools.setup(
     },
     install_requires=[
         "OpenTimelineIO >= 0.12.0",
-        "openassetio >= 1.0.0b1.rev0, < 1.0.0b2.rev0",
-        "openassetio-mediacreation == 1.0.0a7",
+        "openassetio >= 1.0.0b1.rev0",
+        "openassetio-mediacreation >= 1.0.0a9",
     ],
     extras_require={
         "dev": [
@@ -37,7 +37,7 @@ setuptools.setup(
             "pytest",
             "flake8",
             "twine",
-            "openassetio-manager-bal == 1.0.0a12"
+            "openassetio-manager-bal >= 1.0.0a16"
         ]
     },
     classifiers=[


### PR DESCRIPTION
Part of OpenAssetIO/OpenAssetIO#1311. Deprecated aliases have been removed from the latest OpenAssetIO, but the version of MediaCreation that was pinned in `setup.py` still used them.

This wasn't actually a problem, since the version of OpenAssetIO was also pinned.

However, it is a useful canary if we only specify a minimum range for downstream projects, whenever possible. Upon the next OpenAssetIO release we should re-check this project (and others) for compatibility.

So remove the maximum bound for OpenAssetIO, bump the minimum bound for OpenAssetIO-MediaCreation, and bump the minimum BAL version used for testing, such that it supports the later OpenAssetIO versions.